### PR TITLE
fix(people-schema): miscopied stackoverflow

### DIFF
--- a/schemas/people-schema.json
+++ b/schemas/people-schema.json
@@ -62,11 +62,10 @@
       "format": "uri",
       "examples": ["https://medium.com/@miporagi"]
     },
-    "website": {
+    "stackoverflow": {
       "$id": "#/properties/stackoverflow",
       "type": "string",
       "title": "Stackoverflow profile link",
-      "description": "Your personal blog or website (it has to be about you)",
       "format": "uri",
       "examples": ["https://stackoverflow.com/users/1348195/benjamin-gruenbaum"]
     },


### PR DESCRIPTION
This caused duplicate object key "website". Note that irrelevant description were removed so consider re-adding description if needed.